### PR TITLE
Add openbox as a simple window manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mmmaxwwwell/wine6:latest
 
 RUN apt update --allow-releaseinfo-change \
     && DEBIAN_FRONTEND="noninteractive" \
-    apt install -y procps htop winbind x11vnc net-tools \
+    apt install -y procps htop winbind x11vnc net-tools openbox \
     && apt autoclean \
     && apt autoremove -y
 

--- a/xvfb-entrypoint.sh
+++ b/xvfb-entrypoint.sh
@@ -13,5 +13,7 @@ runuser -u wine -- bash -c 'x11vnc -display WAIT:99 -forever -autoport 5900 -aut
 echo "Waiting 5 seconds for X server to initialize..."
 sleep 5
 
+runuser -u wine -- bash -c 'DISPLAY=:99 openbox &'
+
 # Open up file browser
 runuser -u wine -- bash -c 'DISPLAY=":99" winefile'


### PR DESCRIPTION
Currently with no window manager it's not possible to close any pop-ups from the torch server without closing the entire program process. Adding a window manager will make the mod/plugin menus more accessible.